### PR TITLE
Add an indication that a dummy unblock() is used

### DIFF
--- a/lib/unblock.js
+++ b/lib/unblock.js
@@ -21,6 +21,7 @@ MeteorX.Session.prototype._startSubscription = function (handler, subId, params,
   // _startSubscription may call from a lot places
   // so cachedUnblock might be null in somecases
   if(!unblockHander) {
+    sub.isDummyUnblock = true;
     unblockHander = function() {}
   }
   // assign the cachedUnblock

--- a/lib/unblock.js
+++ b/lib/unblock.js
@@ -3,7 +3,7 @@ var cachedUnblock;
 var originalSub = MeteorX.Session.prototype.protocol_handlers.sub;
 MeteorX.Session.prototype.protocol_handlers.sub = function(msg, unblock) {
   var self = this;
-  // cacheUnblock temporarly, so we can capture it later
+  // cacheUnblock temporarily, so we can capture it later
   // we will use unblock in current eventLoop, so this is safe
   cachedUnblock = unblock;
   originalSub.call(self, msg, unblock);
@@ -35,14 +35,15 @@ MeteorX.Session.prototype._startSubscription = function (handler, subId, params,
   sub._runHandler();
 };
 
-// sometimes _runHandler will be called directly and 
+// sometimes _runHandler will be called directly and
 // we won't have the session context and cachedUnblock
 // so, those situations, set a dummy function for unblock
 // this happens often when logging in and out
 var originalRunHandler = MeteorX.Subscription.prototype._runHandler;
 MeteorX.Subscription.prototype._runHandler = function() {
   if(!this.unblock) {
+    this.isDummyUnblock = true;
     this.unblock = function() {};
   }
   originalRunHandler.call(this);
-}
+};

--- a/package.js
+++ b/package.js
@@ -12,6 +12,7 @@ Package.on_use(function (api, where) {
 Package.on_test(function(api) {
   configurePackages(api);
 
+  api.use(['random', 'ddp'], 'server');
   api.use('tinytest');
   api.add_files('test/unblock.js', 'server');
 });


### PR DESCRIPTION
Now a user can test for `this.isDummyUnblock` and know when calling `unblock()` will not have the desired effect.

**Bonus:** I believe the changes made to _package.js_ now allow tests to pass under new versions of Meteor :smile: 
